### PR TITLE
fix "'get_property' expects at least one object" error while getting …

### DIFF
--- a/device_tree/data/common_proc.tcl
+++ b/device_tree/data/common_proc.tcl
@@ -2141,7 +2141,7 @@ proc get_intr_cntrl_name { periph_name intr_pin_name } {
 		} elseif { [llength $sink_periph] && [string match -nocase [common::get_property IP_NAME $sink_periph] "xlconcat"] } {
 			# this the case where interrupt port is connected to XLConcat IP.
 			lappend intr_cntrl [get_intr_cntrl_name $sink_periph "dout"]
-		} elseif {[string match -nocase [common::get_property IP_NAME $sink_periph] "xlslice"]} {
+		} elseif { [llength $sink_periph] && [string match -nocase [common::get_property IP_NAME $sink_periph] "xlslice"]} {
 			lappend intr_cntrl [get_intr_cntrl_name $sink_periph "Dout"]
 		}
 		if {[llength $intr_cntrl] > 1} {


### PR DESCRIPTION
…interrupt information

* shoule first determine whether $sink_periph is empty